### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ And ... it's free, opensource, yaaaay!!!
 - Playlist management
 - Last.fm scrobbling
 - Import YouTube playlist
-- Sync Playlist accross devices
+- Sync Playlist across devices
 
 [How to configure UpNext hot keys ?](https://gist.github.com/ptgamr/96caea84b206b7a361a1)
 


### PR DESCRIPTION
@ptgamr, I've corrected a typographical error in the documentation of the [upnext](https://github.com/ptgamr/upnext) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.