### PR TITLE
change random shuffle parameter

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -232,7 +232,7 @@ Player.prototype = {
 
         if (this.state.shuffle) {
 
-            nextIndex = Utils.random(0, this.trackIds.length - 1);
+            nextIndex = Utils.random(0, this.trackIds.length);
 
         } else {
 


### PR DESCRIPTION
Currently, the last song in the playlist will never be played if on shuffle mode.
Changed the parameter to trackIds.length to include the last song.